### PR TITLE
loadTypo.js

### DIFF
--- a/typo/loadTypo.js
+++ b/typo/loadTypo.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// loadTypo returns a promise resolved when the given dictionaries are loaded
+function loadTypo(affPath, dicPath) {
+	return new Promise(function(resolve, reject) {
+		var xhr_aff = new XMLHttpRequest();
+		xhr_aff.open('GET', affPath, true);
+		xhr_aff.onload = function() {
+			if (xhr_aff.readyState === 4 && xhr_aff.status === 200) {
+				//console.log('aff loaded');
+				var xhr_dic = new XMLHttpRequest();
+				xhr_dic.open('GET', dicPath, true);
+				xhr_dic.onload = function() {
+					if (xhr_dic.readyState === 4 && xhr_dic.status === 200) {
+						//console.log('dic loaded');
+						resolve(new Typo('en_US', xhr_aff.responseText, xhr_dic.responseText, { platform: 'any' }));
+					} else {
+						//console.log('failed loading dic');
+						reject();
+					}
+				};
+				//console.log('loading dic');
+				xhr_dic.send(null);
+			} else {
+				//console.log('failed loading aff');
+				reject();
+			}
+		};
+		//console.log('loading aff');
+		xhr_aff.send(null);
+	});
+}


### PR DESCRIPTION
Implements a loadTypo function that returns a promise resolved when the given dictionaries are loaded

`
const aff = 'https://cdn.rawgit.com/kofifus/Typo.js/312bf158a814dda6eac3bd991e3a133c84472fc8/typo/dictionaries/en_US/en_US.aff';
const dic = 'https://cdn.rawgit.com/kofifus/Typo.js/312bf158a814dda6eac3bd991e3a133c84472fc8/typo/dictionaries/en_US/en_US.dic';
let typoLoaded=loadTypo(aff, dic);
typoLoaded.then(typo => { do something with typo }; );
`